### PR TITLE
update CORS configuration to allow specific origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ const app = express();
 const port = process.env.PORT || 5000;
 
 app.use(express.json());
-app.use(cors({ origin: "*" }));
+app.use(
+  cors({
+    origin: "http://localhost:3000",
+    credentials: true,
+  }),
+);
 
 app.use("/auth", AuthRoute);
 app.use("/users", userRoute);


### PR DESCRIPTION
This pull request updates the CORS configuration in the `index.js` file to restrict allowed origins and support credentials, improving security for cross-origin requests.

CORS configuration changes:

* Changed the CORS middleware to only allow requests from `http://localhost:3000` and enabled credentials support, instead of allowing all origins.